### PR TITLE
Include a polygon triangulation to master

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,5 +1,11 @@
 # This file is machine-generated - editing it directly is not advised
 
+[[Adapt]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "fd04049c7dd78cfef0b06cdc1f0f181467655712"
+uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+version = "1.1.0"
+
 [[Arpack]]
 deps = ["Arpack_jll", "Libdl", "LinearAlgebra"]
 git-tree-sha1 = "2ff92b71ba1747c5fdd541f8fc87736d82f40ec9"
@@ -131,6 +137,18 @@ git-tree-sha1 = "5ad1c36bff608560df500e93aaeb5b86b4ad45ba"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 version = "0.23.3"
 
+[[EarCut]]
+deps = ["EarCut_jll", "GeometryBasics"]
+git-tree-sha1 = "77066358ee4c199ce9eeaa3e4f87e95cedeca472"
+uuid = "5160dea5-cc57-53b0-be5f-ac191989508a"
+version = "2.0.0"
+
+[[EarCut_jll]]
+deps = ["Libdl", "Pkg"]
+git-tree-sha1 = "eabac56550a7d7e0be499125673fbff560eb8b20"
+uuid = "5ae413db-bbd1-5e63-b57d-d24a61df00f5"
+version = "2.1.5+0"
+
 [[FilePathsBase]]
 deps = ["Dates", "LinearAlgebra", "Printf", "Test", "UUIDs"]
 git-tree-sha1 = "923fd3b942a11712435682eaa95cc8518c428b2c"
@@ -171,6 +189,12 @@ git-tree-sha1 = "764133c6a584cb61a62d798f47598af8c8fcb7c5"
 uuid = "323cb8eb-fbf6-51c0-afd0-f8fba70507b2"
 version = "0.10.0"
 
+[[GeometryBasics]]
+deps = ["IterTools", "LinearAlgebra", "StaticArrays", "StructArrays", "Tables"]
+git-tree-sha1 = "998f783c38234e9909993ee9de9316b66bbd8aa8"
+uuid = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
+version = "0.2.12"
+
 [[InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
@@ -180,6 +204,11 @@ deps = ["Test"]
 git-tree-sha1 = "15732c475062348b0165684ffe28e85ea8396afc"
 uuid = "41ab1584-1d38-5bbf-9106-f11c6c58b48f"
 version = "1.0.0"
+
+[[IterTools]]
+git-tree-sha1 = "05110a2ab1fc5f932622ffea2a003221f4782c18"
+uuid = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
+version = "1.3.0"
 
 [[IteratorInterfaceExtensions]]
 git-tree-sha1 = "a3f24677c21f5bbe9d2a714f95dcd58337fb2856"
@@ -371,9 +400,9 @@ version = "0.6.1"
 
 [[Rmath_jll]]
 deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "1660f8fefbf5ab9c67560513131d4e933012fc4b"
+git-tree-sha1 = "d76185aa1f421306dec73c057aa384bad74188f0"
 uuid = "f50d1b31-88e8-58de-be2c-1cc44531875f"
-version = "0.2.2+0"
+version = "0.2.2+1"
 
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
@@ -430,6 +459,12 @@ deps = ["Rmath", "SpecialFunctions"]
 git-tree-sha1 = "04a5a8e6ab87966b43f247920eab053fd5fdc925"
 uuid = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 version = "0.9.5"
+
+[[StructArrays]]
+deps = ["Adapt", "DataAPI", "Tables"]
+git-tree-sha1 = "10ee2e9b8a222ef7aac886b12cc8c050db9a8a45"
+uuid = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
+version = "0.4.3"
 
 [[SuiteSparse]]
 deps = ["Libdl", "LinearAlgebra", "Serialization", "SparseArrays"]

--- a/Project.toml
+++ b/Project.toml
@@ -5,8 +5,10 @@ version = "0.1.0"
 
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
+EarCut = "5160dea5-cc57-53b0-be5f-ac191989508a"
 GeoStats = "dcc97b0b-8ce5-5539-9008-bb190f959ef6"
 GeoStatsBase = "323cb8eb-fbf6-51c0-afd0-f8fba70507b2"
+GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/FluxConservative.jl
+++ b/src/FluxConservative.jl
@@ -2,6 +2,8 @@ module FluxConservative
 
 using GeoStats
 using Distances
+using GeometryBasics
+using EarCut
 
 import GeoStatsBase: solve
 
@@ -19,6 +21,9 @@ export AreaHaversine
 end
 
 function GeoStatsBase.solve(problem::EstimationProblem, solver::FluxConservWeights)
+        @assert isa(problem.sdomain,RegularGrid) "For the moment only RegularGrids are supported \n Please check your input"
+        @assert isa(problem.sdata.domain,RegularGrid) "For the moment only RegularGrids are supported \n Please check your input"
+
         pdata=data(problem)
 
         ### Estimate grid corners....

--- a/src/areas/euclidean.jl
+++ b/src/areas/euclidean.jl
@@ -5,8 +5,8 @@ end
 AreaEuclidean() = AreaEuclidean(0.)
 
 function (area::AreaEuclidean)(X::PointSet,Y::PointSet)
-    x=coordinates(X)
-    y=coordinates(Y)
+    x=GeoStats.coordinates(X)
+    y=GeoStats.coordinates(Y)
 
     #bottom_left
     x1=max(x[1,1],y[1,1])

--- a/src/areas/haversine.jl
+++ b/src/areas/haversine.jl
@@ -5,10 +5,12 @@ end
 AreaHaversine() = AreaHaversine(6731.)
 
 function (area::AreaHaversine)(X::PointSet,Y::PointSet)
-    ## To estimate a spherical quadrilateral we can split it into two spherical triangles....
-    ## but first we have to get the 4 coordinates of the overlap
-    x=coordinates(X)
-    y=coordinates(Y)
+    ## To estimate a spherical quadrilateral we can split it into spherical triangles....
+    ## And use spherical geometry to estimate the area
+    ## but first we have to get the 4 coordinates of the overlap polygon
+
+    x=GeoStats.coordinates(X)
+    y=GeoStats.coordinates(Y)
 
     #bottom_left
     x1=max(x[1,1],y[1,1])
@@ -27,10 +29,12 @@ function (area::AreaHaversine)(X::PointSet,Y::PointSet)
     y4=y3
 
     Z=PointSet([x1 x2 x3 x4;y1 y2 y3 y4])
-    z=coordinates(Z)
+    z=GeoStats.coordinates(Z)
+    Zpoints=Conv2SetPoint(Z)
+    triangles=EarCut.triangulate([Zpoints])
     A = 0.
 
-    for sel in ([1,2,3],[1,3,4])
+    for sel in triangles
 
         a=haversine(z[:,sel[1]],z[:,sel[2]],1)
         b=haversine(z[:,sel[2]],z[:,sel[3]],1)

--- a/src/helper.jl
+++ b/src/helper.jl
@@ -5,7 +5,7 @@
 
 """
 function getCorners(X::RegularGrid)
-    cds=coordinates(X)
+    cds=GeoStats.coordinates(X)
     spacing=X.spacing./2
     corners=[]
 
@@ -15,7 +15,11 @@ function getCorners(X::RegularGrid)
     sides=collect(spacing) .* idx
 
     corners=map(x -> PointSet(x.+ sides),eachcol(cds))
-    (coords=coordinates(X)',bounds=corners)
+    (coords=GeoStats.coordinates(X)',bounds=corners)
+end
+
+function getCorners(X::StructuredGrid)
+
 end
 
 
@@ -25,8 +29,8 @@ end
 check if rectangles overlap....
 """
 function doOverlap(X::PointSet,Y::PointSet)
-        x=coordinates(X)
-        y=coordinates(Y)
+        x=GeoStats.coordinates(X)
+        y=GeoStats.coordinates(Y)
         # is one rectangle on left of the other ?
         a=x[1,4] >= y[1,2] || y[1,4] >= x[1,2]
         # is one rectangle on top of the other ?
@@ -54,4 +58,17 @@ function EstCellAreas(X,Y,area)
                 push!(areacella,(xnum,srcidx,cellarea))
         end
         return areacella
+end
+
+"""
+    Conv2SetPoint(X::PointSet)
+
+convert a PointSet type to a set of Points in Array{Array{Point}} format for polygon triangulation
+"""
+function Conv2SetPoint(X::PointSet)
+        x=GeoStats.coordinates(X)
+        T=typeof(x[1,1])
+        out=Array{Point2{T}}(undef,0)
+        [push!(out,Point2(xcol[1],xcol[2])) for xcol in eachcol(x)]
+        return out
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,24 +1,69 @@
-using Test, GeoStats, FluxConservative
+using Test, FluxConservative, GeoStats
 
 ## TESTING IS QUIT UNSTRUCTURED AND BRUTAL....
+###
+@testset "RegularGrid" begin
 
-target=:tas
-dims=(1,1)
-spacings=(360/dims[1],180/dims[2])
-onset=(-180,-90).+spacings./2
-data1=rand(dims[1],dims[2])
-SG=RegularGrid(dims,onset,spacings)
+    @testset "Test Helpers" begin
+        @test 1 == 1
+    end
 
-dims=(36,18)
-spacings=(360/dims[1],180/dims[2])
-onset=(-180,-90).+spacings./2
-data1=rand(dims[1],dims[2])
-SD = RegularGridData(OrderedDict(target => data1),onset,spacings)
 
-problem = EstimationProblem(SD, SG, target)
+    @testset "nothing" begin
+        ### remapping to the same grids....
+        ### Applies a remapping with the same grid as an output
+        ### output should be the input since area weights are always 1
+        target=:tas
+        dims=(36,18)
+        spacings=(360/dims[1],180/dims[2])
+        onset=(-180,-90).+spacings./2
+        data1=rand(dims[1],dims[2])
+        SG=RegularGrid(dims,onset,spacings)
 
-solver = FluxConservWeights(target => (order=1,area=AreaEuclidean()))
-solution = solve(problem, solver)
-out=solution[target]
+        dims=(36,18)
+        spacings=(360/dims[1],180/dims[2])
+        onset=(-180,-90).+spacings./2
+        data1=rand(dims[1],dims[2])
+        SD = RegularGridData(OrderedDict(target => data1),onset,spacings)
 
-@test mean(data1) ≈ out.mean[1,1]
+        problem = EstimationProblem(SD, SG, target)
+        solver = FluxConservWeights(target => (order=1,area=AreaEuclidean()))
+        solution = solve(problem, solver)
+        out=solution[target]
+
+        @test minimum(data1 .≈ out.mean) ## check if minimum = 1
+
+        problem = EstimationProblem(SD, SG, target)
+        solver = FluxConservWeights(target => (order=1,area=AreaHaversine()))
+        solution = solve(problem, solver)
+        out=solution[target]
+
+        @test minimum(data1 .≈ out.mean) ## check if minimum = 1
+
+    end
+
+    @testset "global" begin
+        ### Estimate a global mean with Euclidean Area of Regular Grids...
+        ### ... output should be an array mean
+        target=:tas
+        dims=(1,1)
+        spacings=(360/dims[1],180/dims[2])
+        onset=(-180,-90).+spacings./2
+        data1=rand(dims[1],dims[2])
+        SG=RegularGrid(dims,onset,spacings)
+
+        dims=(36,18)
+        spacings=(360/dims[1],180/dims[2])
+        onset=(-180,-90).+spacings./2
+        data1=rand(dims[1],dims[2])
+        SD = RegularGridData(OrderedDict(target => data1),onset,spacings)
+
+        problem = EstimationProblem(SD, SG, target)
+        solver = FluxConservWeights(target => (order=1,area=AreaEuclidean()))
+        solution = solve(problem, solver)
+        out=solution[target]
+
+        @test mean(data1) ≈ out.mean[1,1]
+    end
+
+end ## END REGULAR TESTING


### PR DESCRIPTION
 	+ including a polygon triangulation to allow a more flexible area calculation
	+ progress on runtest with a more structured testing environment

	modified:   Manifest.toml
	modified:   Project.toml
		    added EarCut package for polygon triangulation
                    added GeometryBasics package

	modified:   src/FluxConservative.jl
                    added an input assertion only allowing RegularGrids for the moment

	modified:   src/areas/euclidean.jl
	modified:   src/areas/haversine.jl
                    included a polygon triangulation

	modified:   src/helper.jl
                    added a function for PointSet conversion to allow the use of EarCut.triangulation

	modified:   test/runtests.jl


       General modification:
                   Since GeometryBasics and GeoStats use the function coordinates, calling it has been precised